### PR TITLE
Fix 'periphery' changed to 'python-periphery'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The Python software has several pre-requisites. To install them on your Raspberr
 sudo apt-get install python-pip ipython
 sudo apt-get install python-numpy python-scipy
 sudo apt-get install libopencv-dev python-opencv
-sudo pip install periphery picamera imutils pillow
+sudo pip install python-periphery picamera imutils pillow
 ```
 
 #### Enable I2C


### PR DESCRIPTION
The `periphery` dependency link is broken.
```bash
$ sudo pip install periphery
Collecting periphery
ERROR: Could not find a version that satisfies the requirement periphery (from versions: none)
ERROR: No matching distribution found for periphery
```
I updated the README.md with the `python-periphery` which seems to be the actual link for the project

```bash
$ sudo pip install python-periphery
Collecting python-periphery
Downloading https://files.pythonhosted.org/packages/52/0e/b5bf7e8cfee3fbb843c2f5b5399da9a65e7c985b67e18f6e73d6da4fb132/python_periphery-1.1.2-py2.py3-none-any.whl
Installing collected packages: python-periphery
Successfully installed python-periphery-1.1.2
